### PR TITLE
fix(Metadata): Fetch magic hash and reattempt api call on unauthorize…

### DIFF
--- a/src/integTest/java/info/blockchain/wallet/metadata/MetadataIntegTest.java
+++ b/src/integTest/java/info/blockchain/wallet/metadata/MetadataIntegTest.java
@@ -32,7 +32,10 @@ public class MetadataIntegTest extends BaseIntegTest {
 
         Metadata metadata = new Metadata.Builder(metaDataHDNode, 2)
             .build();
-        metadata.putMetadata(new PublicContactDetails("Yolo1").toJson());
+        metadata.putMetadata(new PublicContactDetails("hello").toJson());
+        metadata.setMagicHash(null);
+        metadata.putMetadata(new PublicContactDetails("hello").toJson());
+        metadata.deleteMetadata(new PublicContactDetails("hello").toJson());
 
         metadata = new Metadata.Builder(metaDataHDNode, 2)
             .build();

--- a/src/test/java/info/blockchain/wallet/MockInterceptor.java
+++ b/src/test/java/info/blockchain/wallet/MockInterceptor.java
@@ -1,15 +1,22 @@
 package info.blockchain.wallet;
 
+import info.blockchain.wallet.payload.PayloadManager;
 import java.io.IOException;
 import java.util.LinkedList;
+import java.util.NoSuchElementException;
 import okhttp3.HttpUrl;
 import okhttp3.Interceptor;
 import okhttp3.MediaType;
 import okhttp3.Protocol;
 import okhttp3.Response;
 import okhttp3.ResponseBody;
+import org.apache.commons.cli.MissingArgumentException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class MockInterceptor implements Interceptor {
+
+    private static Logger log = LoggerFactory.getLogger(MockInterceptor.class);
 
     static MockInterceptor instance;
 
@@ -62,7 +69,14 @@ public class MockInterceptor implements Interceptor {
         final String query = uri.query();
         final String method = chain.request().method();
 
-        String responseString = responseStringList.getFirst();
+        String responseString = null;
+
+        try {
+            responseString = responseStringList.getFirst();
+        } catch (NoSuchElementException e) {
+            log.error("Missing mock response", e);
+        }
+
         if(responseCodeList == null || responseCodeList.size() == 0) {
             responseCodeList = new LinkedList<>();
             responseCodeList.add(200);


### PR DESCRIPTION
…d error.

Simultaneous cross platform use of metadata for the same wallet will unsync the magic hash used for validating entries.
Solution: If a call to metadata fails with an unauthorised error, the magic hash will be requested from the server and the save will be reattempted.