### PR TITLE
feature(ShapeShift): Parse API errors

### DIFF
--- a/src/main/java/info/blockchain/wallet/shapeshift/data/QuoteRequest.java
+++ b/src/main/java/info/blockchain/wallet/shapeshift/data/QuoteRequest.java
@@ -22,6 +22,10 @@ public class QuoteRequest {
     @JsonProperty("amount")
     private double amount;
 
+    //the amount to be withdrawn
+    @JsonProperty("withdrawalAmount")
+    private String withdrawalAmount;
+
     //the address for coin to be sent to
     @JsonProperty("withdrawal")
     private String withdrawal;
@@ -44,6 +48,14 @@ public class QuoteRequest {
 
     public void setAmount(double amount) {
         this.amount = amount;
+    }
+
+    public String getWithdrawalAmount() {
+        return withdrawalAmount;
+    }
+
+    public void setWithdrawalAmount(String withdrawalAmount) {
+        this.withdrawalAmount = withdrawalAmount;
     }
 
     public String getWithdrawal() {

--- a/src/main/java/info/blockchain/wallet/shapeshift/data/QuoteResponseWrapper.java
+++ b/src/main/java/info/blockchain/wallet/shapeshift/data/QuoteResponseWrapper.java
@@ -17,7 +17,14 @@ public class QuoteResponseWrapper {
     @JsonProperty("success")
     private Quote wrapper;
 
+    @JsonProperty("error")
+    private String error;
+
     public Quote getWrapper() {
         return wrapper;
+    }
+
+    public String getError() {
+        return error;
     }
 }

--- a/src/main/java/info/blockchain/wallet/shapeshift/data/SendAmountResponseWrapper.java
+++ b/src/main/java/info/blockchain/wallet/shapeshift/data/SendAmountResponseWrapper.java
@@ -17,7 +17,14 @@ public class SendAmountResponseWrapper {
     @JsonProperty("success")
     private Quote wrapper;
 
+    @JsonProperty("error")
+    private String error;
+
     public Quote getWrapper() {
         return wrapper;
+    }
+
+    public String getError() {
+        return error;
     }
 }


### PR DESCRIPTION
The ShapeShift API can return `200: { "error": [...] }` so this allows for that to be parsed.